### PR TITLE
fix broken shebang.

### DIFF
--- a/bin/dket-venv-setup
+++ b/bin/dket-venv-setup
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 
 PYTHON=python3
 VENV_DIR=.py3venv


### PR DESCRIPTION
the broken shebang causes the script to try to use python 2.7 if run
from a different shell like zsh.